### PR TITLE
Wonky DM/Group Call Buttons Fix

### DIFF
--- a/nocturnal/importCSS/core.css
+++ b/nocturnal/importCSS/core.css
@@ -2720,10 +2720,6 @@ svg[name=Nitro] g path {
 	border-radius: 5px;
 }
 
-.controlButton-2MhVEL foreignObject {
-	mask: none;
-}
-
 .contextMenuNub-3yOOYo {
 	bottom: 4px;
 	right: 4px;
@@ -3662,4 +3658,9 @@ div[aria-label="USER_SETTINGS"] .info-1VyQPT:last-child > div:last-child::after 
 
 .inputInner-2akrSS {
 	border: 1px solid var(--deprecated-text-input-border);
+}
+
+.controlButton-2MhVEL foreignObject {
+	mask: none;
+	padding-top: 6px;
 }


### PR DESCRIPTION
This fixes the wonky buttons you get in DM/Group calls namely the "Turn On Camera" and "Mute" buttons.

The fix includes moving the .controlButton-2MhVEL section to the bottom and adding padding-top: 6px; to it.